### PR TITLE
fix: validate security-insights files for schema versions >= 2.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,29 @@ jobs:
 
       - name: Validate Security Insights
         uses: ./
+
+  reject-invalid:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        file:
+          - testdata/invalid-v2.1.0.yml
+          - testdata/invalid-v2.2.0.yml
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Validate (expect failure)
+        id: validate
+        uses: ./
+        with:
+          file: ${{ matrix.file }}
+        continue-on-error: true
+
+      - name: Assert validation failed
+        if: steps.validate.outcome == 'success'
+        shell: bash
+        run: |
+          echo "::error::Validation should have failed for ${{ matrix.file }}"
+          exit 1

--- a/action.yml
+++ b/action.yml
@@ -21,9 +21,16 @@ runs:
     - name: Download schema
       shell: bash
       run: |
-        curl -fsSL \
-          "https://raw.githubusercontent.com/ossf/security-insights/v${{ steps.version.outputs.schema-version }}/spec/schema.cue" \
-          -o schema.cue
+        VERSION="${{ steps.version.outputs.schema-version }}"
+        BASE="https://raw.githubusercontent.com/ossf/security-insights/v${VERSION}"
+        if ! curl -fsSL "${BASE}/spec/schema.cue" -o schema.cue 2>/dev/null; then
+          curl -fsSL "${BASE}/schema.cue" -o schema.cue
+        fi
     - name: Validate
       shell: bash
-      run: cue vet schema.cue "${{ inputs.file }}"
+      run: |
+        if grep -q '^#SecurityInsights:' schema.cue; then
+          cue vet -d '#SecurityInsights' schema.cue "${{ inputs.file }}"
+        else
+          cue vet schema.cue "${{ inputs.file }}"
+        fi

--- a/testdata/invalid-v2.1.0.yml
+++ b/testdata/invalid-v2.1.0.yml
@@ -1,0 +1,8 @@
+header:
+  schema-version: 2.1.0
+  last-updated: "2026-03-17"
+  last-reviewed: "2026-03-17"
+  url: https://example.com/security-insights.yml
+project:
+  name: Test Project
+  homepage: https://example.com

--- a/testdata/invalid-v2.2.0.yml
+++ b/testdata/invalid-v2.2.0.yml
@@ -1,0 +1,8 @@
+header:
+  schema-version: 2.2.0
+  last-updated: "2026-03-17"
+  last-reviewed: "2026-03-17"
+  url: https://example.com/security-insights.yml
+project:
+  name: Test Project
+  homepage: https://example.com


### PR DESCRIPTION
Fixes https://github.com/revanite-io/security-insights-action/issues/2

## What/Why

Schema versions 2.1.0+ restructured the CUE schema to use a `#SecurityInsights` definition instead of bare top-level fields, and moved the file from the repo root into `spec/`. This caused `cue vet` to silently pass on any input since there were no concrete constraints to validate against.

## Proof it works

CI now includes negative test cases (`reject-invalid` job) that run the action against intentionally incomplete v2.1.0 and v2.2.0 files and assert that validation fails. The existing `validate` job continues to verify the repo's own valid security-insights file passes.

## Risk + AI role

Low -- the fix is two small shell conditionals in a composite action. AI-assisted analysis and implementation, human-reviewed.

## Review focus

- Confirm the content-based detection (`grep -q '^#SecurityInsights:'`) is robust enough vs. version-string comparison
- Whether the `curl` fallback approach (try `spec/` first, fall back to root) handles edge cases cleanly when both paths 404