### PR TITLE
chore: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,14 +9,23 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
     steps:
-      - uses: actions/checkout@v6
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
@@ -25,13 +34,19 @@ jobs:
 
   reject-invalid:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Clone the repository
     strategy:
       matrix:
         file:
           - testdata/invalid-v2.1.0.yml
           - testdata/invalid-v2.2.0.yml
     steps:
-      - uses: actions/checkout@v6
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: cue-lang/setup-cue@v1.0.1
+    - uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
     - name: Extract schema version
       id: version
       shell: bash


### PR DESCRIPTION
## What/Why

Apply GHA security standards: deny-all permissions at workflow level with per-job grants, pin all action refs to commit SHAs, add harden-runner as first step in every job, add concurrency group for PR dedup, and rename workflow to `.yaml` extension.

## Proof it works

No test framework for composite actions. CI itself validates correctness on push -- the existing `validate` and `reject-invalid` jobs exercise the action end-to-end.

## Risk + AI role

Low -- no behavioral changes to the action itself, only CI hardening and ref pinning. AI-assisted implementation, human-reviewed.

## Review focus

- Verify the pinned SHAs match the expected tag versions
- Confirm harden-runner `egress-policy: audit` is the right starting posture